### PR TITLE
Use comdlg32's Open File dialog and document keyboard commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,16 @@ hexed - a Windows console-based hex editor
 
 [![Build status](https://ci.appveyor.com/api/projects/status/1mjm8674l9ardj0t?svg=true)](https://ci.appveyor.com/project/izzo/hexed)
 
+## Keyboard shortcuts
+* Navigation: **Left**, **Right**, **Up**, **Down**
+
+  **Home/End** to jump to the _start_/_end_ of current row
+  
+  **PageUp**/**PageDown** skips to the _first_/_last_ row while maintaing column alignment
+* Redraw display: **F5**
+* Enter/Exit edit mode: **Insert/Escape**, goes into _byte_ (Hex) editing mode by default
+* Switch between edit modes: **Tab**, currently two modes are supported, _byte_ (Hex) and _char_ (ASCII)
+* Quit: **Escape**, when not in edit mode
+
+## Sample session
 ![hexed.gif](/hexed.gif)

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -14,11 +14,26 @@ void RemapColours(HANDLE stdoutHandle);
 
 int main(int argc, char** argv)
 {
+	char *fname = NULL;
     if (argc != 2)
     {
-        printf("usage: hexed <filename>\n");
-        return 0;
-    }
+		OPENFILENAME ofn;
+		ZeroMemory(&ofn, sizeof ofn);
+		ofn.lStructSize = sizeof ofn;
+		ofn.lpstrFilter = "All files\0*.*\0\0";
+		ofn.nFilterIndex = 1;
+		ofn.lpstrFile = fname = new char[MAX_PATH];
+		ofn.nMaxFile = MAX_PATH;
+		ofn.Flags = OFN_FILEMUSTEXIST | OFN_FORCESHOWHIDDEN;
+
+		*fname = '\0';
+		if (GetOpenFileName(&ofn) == FALSE) {
+			printf("usage: hexed <filename>\n");
+			delete[] fname;
+			return 0;
+		}
+	} else
+		fname = argv[1];
 
     HANDLE stdinHandle = GetStdHandle(STD_INPUT_HANDLE);
     if (stdinHandle == INVALID_HANDLE_VALUE)
@@ -44,7 +59,7 @@ int main(int argc, char** argv)
     ConsoleBuffer buffer(stdoutHandle);
     Window::SetConsoleBuffer(&buffer);
 	File file;
-	file.Open(argv[1]);
+	file.Open(fname);
     MainWindow mainWindow(&file);
 
     s_running = true;
@@ -81,6 +96,8 @@ int main(int argc, char** argv)
     }
 
     RestoreConsole(stdoutHandle, stdoutHandle);
+	if (fname != argv[1])
+		delete[] fname;
 }
 
 void ProcessInput(const INPUT_RECORD& inputRecord)


### PR DESCRIPTION
GetOpenFileName() is only used when executable is invoked without arguments (argc==1)