### PR TITLE
Vi-style keybindigs and revised README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ hexed - a Windows console-based hex editor
 ## Keyboard shortcuts
 * Navigation: **Left**, **Right**, **Up**, **Down**
 
-  **Home/End** to jump to the _start_/_end_ of current row
+  vi-style keybings (**i, j, k, l**) can also be used in view and byte editing modes.
+
+  **Home/End** to jump to the _start_/_end_ of current row, or the entire file if in combination with **Ctrl**
   
-  **PageUp**/**PageDown** skips to the _first_/_last_ row while maintaing column alignment
+  **PageUp**/**PageDown** advances or rewinds the view of the file a page at a time, or if in combination with **Ctrl**, the _first_/_last_ row of the currently displayed page. Column alignment is preserved
 * Redraw display: **F5**
 * Enter/Exit edit mode: **Insert/Escape**, goes into _byte_ (Hex) editing mode by default
 * Switch between edit modes: **Tab**, currently two modes are supported, _byte_ (Hex) and _char_ (ASCII)

--- a/source/HexView.cpp
+++ b/source/HexView.cpp
@@ -190,6 +190,7 @@ void HexView::OnKeyEvent(KeyEvent& keyEvent)
     switch (vkCode)
     {
         case VK_LEFT:
+        case 'H':
         {
 			if (m_editMode == EditMode_Byte && m_nibbleIndex == 0)
 			{
@@ -213,6 +214,7 @@ void HexView::OnKeyEvent(KeyEvent& keyEvent)
         }
 
         case VK_RIGHT:
+        case 'L':
         {
 			if (m_editMode == EditMode_Byte && m_nibbleIndex == 1)
 			{
@@ -236,6 +238,7 @@ void HexView::OnKeyEvent(KeyEvent& keyEvent)
         }
 
         case VK_UP:
+        case 'K':
         {
             refresh = false;
             int selectedLine = GetSelectedLine();
@@ -256,6 +259,7 @@ void HexView::OnKeyEvent(KeyEvent& keyEvent)
         }
 
         case VK_DOWN:
+        case 'J':
         {
             refresh = false;
             int selectedLine = GetSelectedLine();


### PR DESCRIPTION
1. Vi-style basic navigation keys
2. README.md: Updated. More accurate descriptions of commands that admit a Ctrl- modifier